### PR TITLE
Add workaround to make plugin work for current Gradle versions

### DIFF
--- a/src/main/java/com/yubico/gradle/plugins/signing/gpg/GpgSigningPlugin.java
+++ b/src/main/java/com/yubico/gradle/plugins/signing/gpg/GpgSigningPlugin.java
@@ -1,10 +1,15 @@
 package com.yubico.gradle.plugins.signing.gpg;
 
 import com.yubico.gradle.plugins.signing.gpg.signatory.GpgSignatoryProvider;
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.plugins.signing.Sign;
 import org.gradle.plugins.signing.SigningExtension;
 import org.gradle.plugins.signing.SigningPlugin;
+import org.gradle.plugins.signing.signatory.Signatory;
+
+import java.util.concurrent.Callable;
 
 public class GpgSigningPlugin implements Plugin<Project> {
 
@@ -13,6 +18,18 @@ public class GpgSigningPlugin implements Plugin<Project> {
     project.getPluginManager().apply(SigningPlugin.class);
 
     project.getExtensions().getByType(SigningExtension.class).setSignatories(new GpgSignatoryProvider());
+    project.getTasks().withType(Sign.class, new Action<Sign>() {
+      @Override
+      public void execute(Sign sign) {
+        // Workaround bug that prevents using custom signatories
+        sign.getInputs().property("signatory", new Callable<String>() {
+          @Override
+          public String call() throws Exception {
+            return sign.getSignatory().getName();
+          }
+        });
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Since it will be a while until the Gradle PRs are sorted out I was looking for ways to use GPG to sign files without having to use a custom compiled Gradle version. There is a simple way to work around the problem since the error occurs in the `signatory` input property.

The workaround avoids the runtime cast to `PgpSignatory` by replacing the property when the GpgSigningPlugin is applied. The plugin now works fine for me without a patch on Gradle 4.1 and 4.2.

It would be better to apply this only with some kind of Gradle version check but since we don't know when it will be fixed it would be hard to implement. (And if the GPG signatory is directly added to Gradle, you'd just stop using this plugin..)